### PR TITLE
修改支付时，错误提示信息

### DIFF
--- a/src/main/java/com/jiazhe/youxiang/server/common/enums/OrderCodeEnum.java
+++ b/src/main/java/com/jiazhe/youxiang/server/common/enums/OrderCodeEnum.java
@@ -49,6 +49,10 @@ public enum OrderCodeEnum {
     RECHARGE_CARD_IS_EXPIRY(108040,"RECHARGE_CARD_IS_EXPIRY" , "充值卡已过期，不能用于支付"),
     POINT_RECHARGE_CARD_CONCURRENT_PAY(108041,"POINT_RECHARGE_CARD_CONCURRENT_PAY" , "充值卡和积分卡不能同时支付"),
     ORDER_PAYMENT_NOT_ENOUGH(108042, "ORDER_PAYMENT_NOT_ENOUGH", "支付金额不足订单金额，下单失败"),
+    VOUCHER_USED(108043, "VOUCHER_USED", "代金券已被使用"),
+    VOUCHER_STOP_USING(108044, "VOUCHER_STOP_USING", "代金券被停用"),
+    POINT_STOP_USING(108045, "POINT_STOP_USING", "积分卡被停用"),
+    RECHARGE_CARD_STOP_USING(108046, "RECHARGE_CARD_STOP_USING", "充值卡被停用"),
     ;
 
     OrderCodeEnum(Integer code, String type, String message) {

--- a/src/main/java/com/jiazhe/youxiang/server/service/impl/order/OrderInfoServiceImpl.java
+++ b/src/main/java/com/jiazhe/youxiang/server/service/impl/order/OrderInfoServiceImpl.java
@@ -289,8 +289,11 @@ public class OrderInfoServiceImpl implements OrderInfoService {
                 if (!bean.getCustomerId().equals(orderInfoPO.getCustomerId())) {
                     throw new OrderException(OrderCodeEnum.VOUCHER_IS_NOT_YOURS);
                 }
-                if (bean.getStatus().equals(Byte.valueOf("0")) || bean.getUsed().equals(Byte.valueOf("1"))) {
-                    throw new OrderException(OrderCodeEnum.ORDER_VOUCHER_PAY_ERROR);
+                if (bean.getUsed().equals(Byte.valueOf("1"))) {
+                    throw new OrderException(OrderCodeEnum.VOUCHER_USED);
+                }
+                if(bean.getStatus().equals(Byte.valueOf("0"))){
+                    throw new OrderException(OrderCodeEnum.VOUCHER_STOP_USING);
                 }
                 if (bean.getExpiryTime().getTime() < System.currentTimeMillis()) {
                     throw new OrderException(OrderCodeEnum.VOUCHER_IS_EXPIRY);
@@ -336,7 +339,7 @@ public class OrderInfoServiceImpl implements OrderInfoService {
                     throw new OrderException(OrderCodeEnum.POINT_IS_NOT_YOURS);
                 }
                 if (bean.getStatus().equals(Byte.valueOf("0"))) {
-                    throw new OrderException(OrderCodeEnum.ORDER_POINT_CARD_PAY_ERROR);
+                    throw new OrderException(OrderCodeEnum.POINT_STOP_USING);
                 }
                 if (!bean.getCityCodes().contains(orderInfoPO.getCustomerCityCode())) {
                     throw new OrderException(OrderCodeEnum.POINT_NOT_SUPPORT_CITY);
@@ -383,7 +386,7 @@ public class OrderInfoServiceImpl implements OrderInfoService {
                     throw new OrderException(OrderCodeEnum.RECHARGE_CARD_IS_NOT_YOURS);
                 }
                 if (bean.getStatus().equals(Byte.valueOf("0"))) {
-                    throw new OrderException(OrderCodeEnum.ORDER_RECHARGE_CARD_PAY_ERROR);
+                    throw new OrderException(OrderCodeEnum.RECHARGE_CARD_STOP_USING);
                 }
                 if (bean.getExpiryTime().getTime() < System.currentTimeMillis()) {
                     throw new OrderException(OrderCodeEnum.RECHARGE_CARD_IS_EXPIRY);
@@ -500,8 +503,11 @@ public class OrderInfoServiceImpl implements OrderInfoService {
                 if (!bean.getCustomerId().equals(customerDTO.getId())) {
                     throw new OrderException(OrderCodeEnum.VOUCHER_IS_NOT_YOURS);
                 }
-                if (bean.getStatus().equals(Byte.valueOf("0")) || bean.getUsed().equals(Byte.valueOf("1"))) {
-                    throw new OrderException(OrderCodeEnum.ORDER_VOUCHER_PAY_ERROR);
+                if (bean.getUsed().equals(Byte.valueOf("1"))) {
+                    throw new OrderException(OrderCodeEnum.VOUCHER_USED);
+                }
+                if(bean.getStatus().equals(Byte.valueOf("0"))){
+                    throw new OrderException(OrderCodeEnum.VOUCHER_STOP_USING);
                 }
                 if (bean.getExpiryTime().getTime() < System.currentTimeMillis()) {
                     throw new OrderException(OrderCodeEnum.VOUCHER_IS_EXPIRY);
@@ -546,7 +552,7 @@ public class OrderInfoServiceImpl implements OrderInfoService {
                     throw new OrderException(OrderCodeEnum.POINT_IS_NOT_YOURS);
                 }
                 if (bean.getStatus().equals(Byte.valueOf("0"))) {
-                    throw new OrderException(OrderCodeEnum.ORDER_POINT_CARD_PAY_ERROR);
+                    throw new OrderException(OrderCodeEnum.POINT_STOP_USING);
                 }
                 if (!bean.getCityCodes().contains(dto.getCustomerCityCode())) {
                     throw new OrderException(OrderCodeEnum.POINT_NOT_SUPPORT_CITY);
@@ -592,7 +598,7 @@ public class OrderInfoServiceImpl implements OrderInfoService {
                     throw new OrderException(OrderCodeEnum.RECHARGE_CARD_IS_NOT_YOURS);
                 }
                 if (bean.getStatus().equals(Byte.valueOf("0"))) {
-                    throw new OrderException(OrderCodeEnum.ORDER_RECHARGE_CARD_PAY_ERROR);
+                    throw new OrderException(OrderCodeEnum.RECHARGE_CARD_STOP_USING);
                 }
                 if (bean.getExpiryTime().getTime() < System.currentTimeMillis()) {
                     throw new OrderException(OrderCodeEnum.RECHARGE_CARD_IS_EXPIRY);


### PR DESCRIPTION
当代金券被停用或已被使用，出现这个提示信息。提示信息不明确。改提示为两种，1、代金券已被停用 ；2代金券已被使用。后端修改了提示信息
